### PR TITLE
Enforce subscription caps in writes

### DIFF
--- a/conduit-api/app/api/fake_db_test.go
+++ b/conduit-api/app/api/fake_db_test.go
@@ -2,51 +2,57 @@ package api
 
 import (
 	"context"
+	"database/sql"
 
 	"conduit-monorepo/conduit-api/internal/db"
 )
 
 type fakeDB struct {
-	createGroupFn                       func(ctx context.Context, arg db.CreateGroupParams) (db.Group, error)
-	addMembershipFn                     func(ctx context.Context, arg db.AddMembershipParams) (db.Membership, error)
-	upsertOrganizationSubscriptionFn    func(ctx context.Context, arg db.UpsertOrganizationSubscriptionParams) (db.OrganizationSubscription, error)
-	listGroupMembershipsFn              func(ctx context.Context, groupID int64) ([]db.Membership, error)
-	listGroupsByOwnerFn                 func(ctx context.Context, ownerID int64) ([]db.Group, error)
-	createJoinRequestFn                 func(ctx context.Context, arg db.CreateJoinRequestParams) (db.JoinRequest, error)
-	listJoinRequestsByGroupFn           func(ctx context.Context, groupID int64) ([]db.JoinRequest, error)
-	updateJoinRequestStatusFn           func(ctx context.Context, arg db.UpdateJoinRequestStatusParams) (db.JoinRequest, error)
-	updateGroupIsOpenFn                 func(ctx context.Context, arg db.UpdateGroupIsOpenParams) (db.Group, error)
-	deleteMembershipFn                  func(ctx context.Context, arg db.DeleteMembershipParams) (db.Membership, error)
-	updateGroupFn                       func(ctx context.Context, arg db.UpdateGroupParams) (db.Group, error)
-	deleteGroupFn                       func(ctx context.Context, id int64) (db.Group, error)
-	getGroupByIDFn                      func(ctx context.Context, id int64) (db.Group, error)
-	getCollectionFn                     func(ctx context.Context, id int64) (db.Collection, error)
-	closeCollectionFn                   func(ctx context.Context, arg db.CloseCollectionParams) (db.Collection, error)
-	createCollectionFn                  func(ctx context.Context, arg db.CreateCollectionParams) (db.Collection, error)
-	updateCollectionFn                  func(ctx context.Context, arg db.UpdateCollectionParams) (db.Collection, error)
-	deleteCollectionFn                  func(ctx context.Context, arg db.DeleteCollectionParams) (db.Collection, error)
-	createPaymentFn                     func(ctx context.Context, arg db.CreatePaymentParams) (db.Payment, error)
-	createCollectionFormFn              func(ctx context.Context, arg db.CreateCollectionFormParams) (db.CollectionForm, error)
-	updateCollectionFormFn              func(ctx context.Context, arg db.UpdateCollectionFormParams) (db.CollectionForm, error)
-	deleteCollectionFormFn              func(ctx context.Context, id int64) (db.CollectionForm, error)
-	getCollectionFormByCollectionIDFn   func(ctx context.Context, collectionID int64) (db.CollectionForm, error)
-	getCollectionFormByIDFn             func(ctx context.Context, id int64) (db.CollectionForm, error)
-	listCollectionFormFieldsFn          func(ctx context.Context, formID int64) ([]db.CollectionFormField, error)
-	createCollectionFormFieldFn         func(ctx context.Context, arg db.CreateCollectionFormFieldParams) (db.CollectionFormField, error)
-	createFormSubmissionFn              func(ctx context.Context, arg db.CreateFormSubmissionParams) (db.CollectionFormSubmission, error)
-	addFormAnswerFn                     func(ctx context.Context, arg db.AddFormAnswerParams) (db.CollectionFormAnswer, error)
-	getPaymentByStripePaymentIntentIDFn func(ctx context.Context, stripePaymentIntentID string) (db.Payment, error)
-	markPaymentPaidFn                   func(ctx context.Context, id int64) (db.Payment, error)
-	markPaymentFailedFn                 func(ctx context.Context, id int64) (db.Payment, error)
-	listPaymentsByCollectionFn          func(ctx context.Context, collectionID int64) ([]db.Payment, error)
-	listFormSubmissionsByCollectionFn   func(ctx context.Context, collectionID int64) ([]db.CollectionFormSubmission, error)
-	getFormSubmissionByIDFn             func(ctx context.Context, id int64) (db.CollectionFormSubmission, error)
-	updateFormSubmissionFn              func(ctx context.Context, arg db.UpdateFormSubmissionParams) (db.CollectionFormSubmission, error)
-	deleteFormSubmissionFn              func(ctx context.Context, id int64) (db.CollectionFormSubmission, error)
-	listFormAnswersBySubmissionFn       func(ctx context.Context, submissionID int64) ([]db.CollectionFormAnswer, error)
-	getFormAnswerByIDFn                 func(ctx context.Context, id int64) (db.CollectionFormAnswer, error)
-	updateFormAnswerFn                  func(ctx context.Context, arg db.UpdateFormAnswerParams) (db.CollectionFormAnswer, error)
-	deleteFormAnswerFn                  func(ctx context.Context, id int64) (db.CollectionFormAnswer, error)
+	createGroupFn                        func(ctx context.Context, arg db.CreateGroupParams) (db.Group, error)
+	addMembershipFn                      func(ctx context.Context, arg db.AddMembershipParams) (db.Membership, error)
+	upsertOrganizationSubscriptionFn     func(ctx context.Context, arg db.UpsertOrganizationSubscriptionParams) (db.OrganizationSubscription, error)
+	getOrganizationSubscriptionByGroupFn func(ctx context.Context, groupID int64) (db.OrganizationSubscription, error)
+	getUsagePeriodByGroupAndStartFn      func(ctx context.Context, arg db.GetUsagePeriodByGroupAndStartParams) (db.SubscriptionUsagePeriod, error)
+	createUsagePeriodFn                  func(ctx context.Context, arg db.CreateUsagePeriodParams) (db.SubscriptionUsagePeriod, error)
+	countMembersByGroupFn                func(ctx context.Context, groupID int64) (int64, error)
+	withinTxFn                           func(ctx context.Context, fn func(db.Querier) error) error
+	listGroupMembershipsFn               func(ctx context.Context, groupID int64) ([]db.Membership, error)
+	listGroupsByOwnerFn                  func(ctx context.Context, ownerID int64) ([]db.Group, error)
+	createJoinRequestFn                  func(ctx context.Context, arg db.CreateJoinRequestParams) (db.JoinRequest, error)
+	listJoinRequestsByGroupFn            func(ctx context.Context, groupID int64) ([]db.JoinRequest, error)
+	updateJoinRequestStatusFn            func(ctx context.Context, arg db.UpdateJoinRequestStatusParams) (db.JoinRequest, error)
+	updateGroupIsOpenFn                  func(ctx context.Context, arg db.UpdateGroupIsOpenParams) (db.Group, error)
+	deleteMembershipFn                   func(ctx context.Context, arg db.DeleteMembershipParams) (db.Membership, error)
+	updateGroupFn                        func(ctx context.Context, arg db.UpdateGroupParams) (db.Group, error)
+	deleteGroupFn                        func(ctx context.Context, id int64) (db.Group, error)
+	getGroupByIDFn                       func(ctx context.Context, id int64) (db.Group, error)
+	getCollectionFn                      func(ctx context.Context, id int64) (db.Collection, error)
+	closeCollectionFn                    func(ctx context.Context, arg db.CloseCollectionParams) (db.Collection, error)
+	createCollectionFn                   func(ctx context.Context, arg db.CreateCollectionParams) (db.Collection, error)
+	updateCollectionFn                   func(ctx context.Context, arg db.UpdateCollectionParams) (db.Collection, error)
+	deleteCollectionFn                   func(ctx context.Context, arg db.DeleteCollectionParams) (db.Collection, error)
+	createPaymentFn                      func(ctx context.Context, arg db.CreatePaymentParams) (db.Payment, error)
+	createCollectionFormFn               func(ctx context.Context, arg db.CreateCollectionFormParams) (db.CollectionForm, error)
+	updateCollectionFormFn               func(ctx context.Context, arg db.UpdateCollectionFormParams) (db.CollectionForm, error)
+	deleteCollectionFormFn               func(ctx context.Context, id int64) (db.CollectionForm, error)
+	getCollectionFormByCollectionIDFn    func(ctx context.Context, collectionID int64) (db.CollectionForm, error)
+	getCollectionFormByIDFn              func(ctx context.Context, id int64) (db.CollectionForm, error)
+	listCollectionFormFieldsFn           func(ctx context.Context, formID int64) ([]db.CollectionFormField, error)
+	createCollectionFormFieldFn          func(ctx context.Context, arg db.CreateCollectionFormFieldParams) (db.CollectionFormField, error)
+	createFormSubmissionFn               func(ctx context.Context, arg db.CreateFormSubmissionParams) (db.CollectionFormSubmission, error)
+	addFormAnswerFn                      func(ctx context.Context, arg db.AddFormAnswerParams) (db.CollectionFormAnswer, error)
+	getPaymentByStripePaymentIntentIDFn  func(ctx context.Context, stripePaymentIntentID string) (db.Payment, error)
+	markPaymentPaidFn                    func(ctx context.Context, id int64) (db.Payment, error)
+	markPaymentFailedFn                  func(ctx context.Context, id int64) (db.Payment, error)
+	listPaymentsByCollectionFn           func(ctx context.Context, collectionID int64) ([]db.Payment, error)
+	listFormSubmissionsByCollectionFn    func(ctx context.Context, collectionID int64) ([]db.CollectionFormSubmission, error)
+	getFormSubmissionByIDFn              func(ctx context.Context, id int64) (db.CollectionFormSubmission, error)
+	updateFormSubmissionFn               func(ctx context.Context, arg db.UpdateFormSubmissionParams) (db.CollectionFormSubmission, error)
+	deleteFormSubmissionFn               func(ctx context.Context, id int64) (db.CollectionFormSubmission, error)
+	listFormAnswersBySubmissionFn        func(ctx context.Context, submissionID int64) ([]db.CollectionFormAnswer, error)
+	getFormAnswerByIDFn                  func(ctx context.Context, id int64) (db.CollectionFormAnswer, error)
+	updateFormAnswerFn                   func(ctx context.Context, arg db.UpdateFormAnswerParams) (db.CollectionFormAnswer, error)
+	deleteFormAnswerFn                   func(ctx context.Context, id int64) (db.CollectionFormAnswer, error)
 }
 
 var _ db.Querier = (*fakeDB)(nil)
@@ -67,6 +73,16 @@ func (f *fakeDB) ConsumePasswordResetToken(ctx context.Context, tokenHash string
 	return 0, nil
 }
 func (f *fakeDB) CountMembersByGroup(ctx context.Context, groupID int64) (int64, error) {
+	if f.countMembersByGroupFn != nil {
+		return f.countMembersByGroupFn(ctx, groupID)
+	}
+	if f.listGroupMembershipsFn != nil {
+		memberships, err := f.listGroupMembershipsFn(ctx, groupID)
+		if err != nil {
+			return 0, err
+		}
+		return int64(len(memberships)), nil
+	}
 	return 0, nil
 }
 func (f *fakeDB) CreateCollection(ctx context.Context, arg db.CreateCollectionParams) (db.Collection, error) {
@@ -112,7 +128,10 @@ func (f *fakeDB) CreateRefreshToken(ctx context.Context, arg db.CreateRefreshTok
 	return db.RefreshToken{}, nil
 }
 func (f *fakeDB) CreateUsagePeriod(ctx context.Context, arg db.CreateUsagePeriodParams) (db.SubscriptionUsagePeriod, error) {
-	return db.SubscriptionUsagePeriod{}, nil
+	if f.createUsagePeriodFn != nil {
+		return f.createUsagePeriodFn(ctx, arg)
+	}
+	return db.SubscriptionUsagePeriod{GroupID: arg.GroupID, PeriodStart: arg.PeriodStart, PeriodEnd: arg.PeriodEnd, TransactionCount: arg.TransactionCount, GrossAmount: arg.GrossAmount, FeeAmount: arg.FeeAmount}, nil
 }
 func (f *fakeDB) CreateUser(ctx context.Context, email string) (db.User, error) {
 	return db.User{}, nil
@@ -127,13 +146,19 @@ func (f *fakeDB) GetCollectionFormByCollectionID(ctx context.Context, collection
 	return db.CollectionForm{}, nil
 }
 func (f *fakeDB) GetOrganizationSubscriptionByGroup(ctx context.Context, groupID int64) (db.OrganizationSubscription, error) {
-	return db.OrganizationSubscription{}, nil
+	if f.getOrganizationSubscriptionByGroupFn != nil {
+		return f.getOrganizationSubscriptionByGroupFn(ctx, groupID)
+	}
+	return db.OrganizationSubscription{GroupID: groupID, Tier: db.SubscriptionTierFree, MemberLimit: 25, TransactionCapacityPerPeriod: 250, TransactionFeeBps: 50}, nil
 }
 func (f *fakeDB) GetRefreshTokenByTokenID(ctx context.Context, tokenID string) (db.RefreshToken, error) {
 	return db.RefreshToken{}, nil
 }
 func (f *fakeDB) GetUsagePeriodByGroupAndStart(ctx context.Context, arg db.GetUsagePeriodByGroupAndStartParams) (db.SubscriptionUsagePeriod, error) {
-	return db.SubscriptionUsagePeriod{}, nil
+	if f.getUsagePeriodByGroupAndStartFn != nil {
+		return f.getUsagePeriodByGroupAndStartFn(ctx, arg)
+	}
+	return db.SubscriptionUsagePeriod{}, sql.ErrNoRows
 }
 func (f *fakeDB) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
 	return db.User{}, nil
@@ -255,6 +280,14 @@ func (f *fakeDB) MarkPaymentPaid(ctx context.Context, id int64) (db.Payment, err
 func (f *fakeDB) IncrementUsageForPayment(ctx context.Context, arg db.IncrementUsageForPaymentParams) (db.SubscriptionUsagePeriod, error) {
 	return db.SubscriptionUsagePeriod{}, nil
 }
+
+func (f *fakeDB) WithinTx(ctx context.Context, fn func(db.Querier) error) error {
+	if f.withinTxFn != nil {
+		return f.withinTxFn(ctx, fn)
+	}
+	return fn(f)
+}
+
 func (f *fakeDB) RevokeRefreshToken(ctx context.Context, tokenID string) error       { return nil }
 func (f *fakeDB) RevokeRefreshTokensForUser(ctx context.Context, userID int64) error { return nil }
 func (f *fakeDB) UpdateUserPasswordHash(ctx context.Context, arg db.UpdateUserPasswordHashParams) error {

--- a/conduit-api/app/api/groups_handler.go
+++ b/conduit-api/app/api/groups_handler.go
@@ -179,8 +179,41 @@ func (h *GroupsHandler) AddMembership(c *gin.Context) {
 		return
 	}
 
-	m, err := h.db.AddMembership(c.Request.Context(), db.AddMembershipParams{Column1: req.UserID, Column2: groupID, Column3: role})
+	var m db.Membership
+	err = runWithinTx(c.Request.Context(), h.db, func(q db.Querier) error {
+		subscription, err := q.GetOrganizationSubscriptionByGroup(c.Request.Context(), groupID)
+		if err != nil {
+			return err
+		}
+
+		memberships, err := q.ListGroupMemberships(c.Request.Context(), groupID)
+		if err != nil {
+			return err
+		}
+		for _, membership := range memberships {
+			if membership.UserID == req.UserID {
+				m, err = q.AddMembership(c.Request.Context(), db.AddMembershipParams{Column1: req.UserID, Column2: groupID, Column3: role})
+				return err
+			}
+		}
+
+		memberCount, err := q.CountMembersByGroup(c.Request.Context(), groupID)
+		if err != nil {
+			return err
+		}
+		if memberCount >= int64(subscription.MemberLimit) {
+			return newMemberLimitError(subscription.Tier, int64(subscription.MemberLimit), memberCount)
+		}
+
+		m, err = q.AddMembership(c.Request.Context(), db.AddMembershipParams{Column1: req.UserID, Column2: groupID, Column3: role})
+		return err
+	})
 	if err != nil {
+		var limitErr *subscriptionLimitError
+		if errors.As(err, &limitErr) {
+			respondSubscriptionLimitError(c, limitErr)
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to add membership"})
 		return
 	}

--- a/conduit-api/app/api/payments_handler.go
+++ b/conduit-api/app/api/payments_handler.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"conduit-monorepo/conduit-api/internal/db"
 
@@ -130,14 +131,66 @@ func (h *PaymentsHandler) CreatePayment(c *gin.Context) {
 		stripePaymentIntentID = pgtype.Text{String: stripeIntent.ID, Valid: true}
 	}
 
-	payment, err := h.db.CreatePayment(c.Request.Context(), db.CreatePaymentParams{
-		UserID:                callerID,
-		CollectionID:          collection.ID,
-		Amount:                collection.Amount,
-		Column4:               method,
-		StripePaymentIntentID: stripePaymentIntentID,
+	var payment db.Payment
+	err = runWithinTx(c.Request.Context(), h.db, func(q db.Querier) error {
+		subscription, err := q.GetOrganizationSubscriptionByGroup(c.Request.Context(), collection.GroupID)
+		if err != nil {
+			return err
+		}
+
+		periodStart, periodEnd := billingPeriodBounds(time.Now().UTC())
+		usage, err := q.GetUsagePeriodByGroupAndStart(c.Request.Context(), db.GetUsagePeriodByGroupAndStartParams{GroupID: collection.GroupID, PeriodStart: periodStart})
+		if err != nil {
+			if !isNoRowsErr(err) {
+				return err
+			}
+
+			usage, err = q.CreateUsagePeriod(c.Request.Context(), db.CreateUsagePeriodParams{
+				GroupID:          collection.GroupID,
+				PeriodStart:      periodStart,
+				PeriodEnd:        periodEnd,
+				TransactionCount: 0,
+				GrossAmount:      0,
+				FeeAmount:        0,
+			})
+			if err != nil {
+				usage, err = q.GetUsagePeriodByGroupAndStart(c.Request.Context(), db.GetUsagePeriodByGroupAndStartParams{GroupID: collection.GroupID, PeriodStart: periodStart})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if usage.TransactionCount >= subscription.TransactionCapacityPerPeriod {
+			return newTransactionCapacityError(subscription.Tier, int64(subscription.TransactionCapacityPerPeriod), int64(usage.TransactionCount), usage.PeriodStart, usage.PeriodEnd)
+		}
+
+		payment, err = q.CreatePayment(c.Request.Context(), db.CreatePaymentParams{
+			UserID:                callerID,
+			CollectionID:          collection.ID,
+			Amount:                collection.Amount,
+			Column4:               method,
+			StripePaymentIntentID: stripePaymentIntentID,
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = q.IncrementUsageForPayment(c.Request.Context(), db.IncrementUsageForPaymentParams{
+			GroupID:          collection.GroupID,
+			PeriodStart:      usage.PeriodStart,
+			TransactionCount: 1,
+			GrossAmount:      collection.Amount,
+			FeeAmount:        calculateFeeAmount(collection.Amount, subscription.TransactionFeeBps),
+		})
+		return err
 	})
 	if err != nil {
+		var limitErr *subscriptionLimitError
+		if errors.As(err, &limitErr) {
+			respondSubscriptionLimitError(c, limitErr)
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create payment"})
 		return
 	}

--- a/conduit-api/app/api/subscription_policy.go
+++ b/conduit-api/app/api/subscription_policy.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"conduit-monorepo/conduit-api/internal/db"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type transactionRunner interface {
+	WithinTx(ctx context.Context, fn func(db.Querier) error) error
+}
+
+type transactionalQuerier struct {
+	*db.Queries
+	pool *pgxpool.Pool
+}
+
+func NewTransactionalQuerier(pool *pgxpool.Pool) db.Querier {
+	return &transactionalQuerier{Queries: db.New(pool), pool: pool}
+}
+
+func (q *transactionalQuerier) WithinTx(ctx context.Context, fn func(db.Querier) error) error {
+	tx, err := q.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := fn(q.Queries.WithTx(tx)); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+type subscriptionLimitError struct {
+	code        string
+	tier        db.SubscriptionTier
+	limit       int64
+	current     int64
+	periodStart *pgtype.Timestamptz
+	periodEnd   *pgtype.Timestamptz
+}
+
+func (e *subscriptionLimitError) Error() string {
+	return "subscription limit reached"
+}
+
+func newMemberLimitError(tier db.SubscriptionTier, limit, current int64) error {
+	return &subscriptionLimitError{code: "member_limit_reached", tier: tier, limit: limit, current: current}
+}
+
+func newTransactionCapacityError(tier db.SubscriptionTier, limit, current int64, periodStart, periodEnd pgtype.Timestamptz) error {
+	return &subscriptionLimitError{
+		code:        "transaction_capacity_reached",
+		tier:        tier,
+		limit:       limit,
+		current:     current,
+		periodStart: &periodStart,
+		periodEnd:   &periodEnd,
+	}
+}
+
+func respondSubscriptionLimitError(c *gin.Context, err *subscriptionLimitError) {
+	body := gin.H{
+		"error":   err.Error(),
+		"code":    err.code,
+		"tier":    err.tier,
+		"limit":   err.limit,
+		"current": err.current,
+	}
+	if err.periodStart != nil {
+		body["period_start"] = timeToInterface(*err.periodStart)
+	}
+	if err.periodEnd != nil {
+		body["period_end"] = timeToInterface(*err.periodEnd)
+	}
+	c.JSON(409, body)
+}
+
+func runWithinTx(ctx context.Context, q db.Querier, fn func(db.Querier) error) error {
+	runner, ok := q.(transactionRunner)
+	if !ok {
+		return errors.New("transactional database not configured")
+	}
+	return runner.WithinTx(ctx, fn)
+}
+
+func billingPeriodBounds(now time.Time) (pgtype.Timestamptz, pgtype.Timestamptz) {
+	start := time.Date(now.UTC().Year(), now.UTC().Month(), 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, 0).Add(-time.Nanosecond)
+	return pgtype.Timestamptz{Time: start, Valid: true}, pgtype.Timestamptz{Time: end, Valid: true}
+}
+
+func calculateFeeAmount(amount int64, feeBps int32) int64 {
+	if amount <= 0 || feeBps <= 0 {
+		return 0
+	}
+	return (amount*int64(feeBps) + 9999) / 10000
+}

--- a/conduit-api/db/queries/subscriptions.sql
+++ b/conduit-api/db/queries/subscriptions.sql
@@ -2,7 +2,7 @@
 SELECT *
 FROM organization_subscriptions
 WHERE group_id = $1
-LIMIT 1;
+LIMIT 1 FOR UPDATE;
 
 -- name: UpsertOrganizationSubscription :one
 INSERT INTO organization_subscriptions (
@@ -33,7 +33,7 @@ SELECT *
 FROM subscription_usage_periods
 WHERE group_id = $1
   AND period_start = $2
-LIMIT 1;
+LIMIT 1 FOR UPDATE;
 
 -- name: CreateUsagePeriod :one
 INSERT INTO subscription_usage_periods (

--- a/conduit-api/internal/db/subscriptions.sql.go
+++ b/conduit-api/internal/db/subscriptions.sql.go
@@ -74,7 +74,7 @@ const getOrganizationSubscriptionByGroup = `-- name: GetOrganizationSubscription
 SELECT id, group_id, tier, member_limit, transaction_capacity_per_period, transaction_fee_bps, created_at, updated_at
 FROM organization_subscriptions
 WHERE group_id = $1
-LIMIT 1
+LIMIT 1 FOR UPDATE
 `
 
 func (q *Queries) GetOrganizationSubscriptionByGroup(ctx context.Context, groupID int64) (OrganizationSubscription, error) {
@@ -98,7 +98,7 @@ SELECT id, group_id, period_start, period_end, transaction_count, gross_amount, 
 FROM subscription_usage_periods
 WHERE group_id = $1
   AND period_start = $2
-LIMIT 1
+LIMIT 1 FOR UPDATE
 `
 
 type GetUsagePeriodByGroupAndStartParams struct {

--- a/conduit-api/main.go
+++ b/conduit-api/main.go
@@ -31,21 +31,22 @@ func main() {
 	}
 
 	queries := db.New(pool)
+	transactionalQueries := api.NewTransactionalQuerier(pool)
 	tokenManager := auth.NewTokenManager(cfg.JWTSecret, cfg.AccessTTL, cfg.RefreshTTL)
 	resetEmailSender := email.NewResendSender(cfg.ResendAPIKey, cfg.ResendFromEmail)
 	authService := auth.NewService(queries, tokenManager, resetEmailSender, cfg.FrontendURL, cfg.PasswordResetTTL)
 	authHandler := api.NewAuthHandler(authService, cfg.CookieSecure, tokenManager.RefreshTTLSeconds())
-	groupsHandler := api.NewGroupsHandler(queries, api.GroupSubscriptionDefaults{
+	groupsHandler := api.NewGroupsHandler(transactionalQueries, api.GroupSubscriptionDefaults{
 		Tier:                         db.SubscriptionTier(cfg.SubscriptionDefaultTier),
 		MemberLimit:                  cfg.SubscriptionDefaultMemberLimit,
 		TransactionCapacityPerPeriod: cfg.SubscriptionDefaultTransactionCapacityPerPeriod,
 		TransactionFeeBps:            cfg.SubscriptionDefaultTransactionFeeBps,
 	})
 	collectionsHandler := api.NewCollectionsHandler(queries)
-	paymentsHandler := api.NewPaymentsHandler(queries)
+	paymentsHandler := api.NewPaymentsHandler(transactionalQueries)
 	if cfg.StripeSecretKey != "" && cfg.StripeWebhookSecret != "" {
 		stripeGateway := api.NewStripeGateway(cfg.StripeSecretKey, cfg.StripeWebhookSecret, cfg.StripeCurrency)
-		paymentsHandler = api.NewPaymentsHandler(queries, stripeGateway)
+		paymentsHandler = api.NewPaymentsHandler(transactionalQueries, stripeGateway)
 	}
 	formsHandler := api.NewFormsHandler(queries)
 	router := api.NewRouter(authHandler, groupsHandler, collectionsHandler, paymentsHandler, formsHandler, authService)


### PR DESCRIPTION
Implements BE-06 subscription policy enforcement for member additions and payment creation.\n\nSummary:\n- Adds transactional cap checks for member limits and transaction capacity\n- Returns structured 409 policy errors with code/current/limit metadata\n- Keeps generated sqlc output in sync and updates test fakes\n\nValidation:\n- go test ./... in conduit-api